### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,33 +6,33 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-EEPROM_ItemList		KEYWORD1
-CircularBuffer		KEYWORD1
-EEPROMextent		KEYWORD1
+EEPROM_ItemList	KEYWORD1
+CircularBuffer	KEYWORD1
+EEPROMextent	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-readByte		KEYWORD2
-writeByte		KEYWORD2
-updateByte		KEYWORD2
+readByte	KEYWORD2
+writeByte	KEYWORD2
+updateByte	KEYWORD2
 
 readAnything	KEYWORD2
 writeAnything	KEYWORD2
 updateAnything	KEYWORD2
 
-readString		KEYWORD2
-writeString		KEYWORD2
+readString	KEYWORD2
+writeString	KEYWORD2
 updateString	KEYWORD2
 
-clear 			KEYWORD2
+clear	KEYWORD2
 getStartRead	KEYWORD2
-startWrite		KEYWORD2
-printStatus		KEYWORD2
+startWrite	KEYWORD2
+printStatus	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-EEPROMLIST_EMPTY_OWNER		LITERAL1
+EEPROMLIST_EMPTY_OWNER	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords