### PR TITLE
Fix filename case in #include directives

### DIFF
--- a/src/CircularBuffer.hpp
+++ b/src/CircularBuffer.hpp
@@ -3,7 +3,7 @@
 #define __EEPROM_CircularBuffer_H__
 //-------------------------------------------------------------------
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "EEPROMextent.h"
 
 /**

--- a/src/EEPROM_ItemList.hpp
+++ b/src/EEPROM_ItemList.hpp
@@ -5,7 +5,7 @@
 
 #define EEPROMLIST_EMPTY_OWNER	255
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "EEPROMextent.h"
 
 /**

--- a/src/EEPROMextent.cpp
+++ b/src/EEPROMextent.cpp
@@ -4,7 +4,7 @@ author: <Thierry PARIS>
 description: <Class for basic EEPROM functions>
 *************************************************************/
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "EEPROMextent.h"
 
 EEPROMextentClass EEPROMextent;


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename case-sensitive operating systems like Linux.